### PR TITLE
Allow other currencies than USD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitvec"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +102,12 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byteorder"
@@ -190,6 +214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +264,15 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -316,6 +355,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd3dab59b5cf4bc81069ade0fc470341a1ef3ad5fa73e5a8943bed2ec12b2e8"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa04976a81fde04924b40cc4036c4d12841e8bb04325a5cf2ada75731a150a7d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +398,17 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "sp-arithmetic",
  "ureq",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -354,6 +428,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "regex"
@@ -457,6 +537,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-arithmetic"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f1c69966c192d1dee8521f0b29ece2b14db07b9b44d801a94e295234761645"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "serde",
+ "sp-debug-derive",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80275f23b4e7ba8f54dec5f90f016530e7307d2ee9445f617ab986cbe97f31e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sp-std"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35391ea974fa5ee869cb094d5b437688fbf3d8127d64d1b9fed5822a1ed39b12"
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +583,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -517,6 +634,15 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -709,3 +835,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,21 +81,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -125,9 +125,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "console"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -215,9 +215,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -244,9 +244,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -259,9 +259,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 
 [[package]]
 name = "log"
@@ -311,9 +311,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "percent-encoding"
@@ -357,14 +357,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -378,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "ring"
@@ -465,9 +464,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -491,15 +490,6 @@ checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -590,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -608,9 +598,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -618,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -633,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -643,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -656,15 +646,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.38"
-argh = "0.1.4"
-chrono = { version ="0.4.19", features = ["serde"] }
-csv = "1.1.6"
-env_logger = "0.8.3"
+anyhow = "1"
+argh = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+csv = "1"
+env_logger = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ureq = { version = "2.0", features = ["json"] }
-log = "0.4.14"
+ureq = { version = "2", features = ["json"] }
+log = "0.4"
 indicatif = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1"
 ureq = { version = "2", features = ["json"] }
 log = "0.4"
 indicatif = "0.15"
+sp-arithmetic = "3"

--- a/src/api.rs
+++ b/src/api.rs
@@ -156,7 +156,7 @@ impl<'a> Api<'a> {
 				.or_insert(value);
 		}
 
-		Ok(merged.into_iter().map(|(_k, v)| v).collect())
+		Ok(merged.into_iter().map(|(_k, v)| v).rev().collect())
 	}
 
 	/// Returns a vector of prices corresponding to the passed-in vector of Rewards.

--- a/src/api.rs
+++ b/src/api.rs
@@ -134,8 +134,14 @@ impl<'a> Api<'a> {
 		for reward in rewards {
 			let day = NaiveDateTime::from_timestamp(reward.block_timestamp.try_into()?, 0).date();
 			let amount: u128 = reward.amount.parse()?;
-			let value = RewardEntry { block_num: reward.block_num, day, amount };
-			merged.entry(day).or_insert(value).amount += amount;
+			let value = RewardEntry { block_nums: vec![reward.block_num], day, amount };
+			merged
+				.entry(day)
+				.and_modify(|e: &mut RewardEntry| {
+					e.block_nums.push(reward.block_num);
+					e.amount += amount;
+				})
+				.or_insert(value);
 		}
 
 		Ok(merged.into_iter().map(|(_k, v)| v).collect())

--- a/src/api.rs
+++ b/src/api.rs
@@ -150,7 +150,9 @@ impl<'a> Api<'a> {
 		for r in rewards.iter() {
 			self.progress.map(|p| p.inc(1));
 			// coingecko allows 100 requests per minute
-			std::thread::sleep(std::time::Duration::from_millis(600));
+			// it seems to be a bit oversensitive. We therefore restrain outselfs
+			// to 60 requests a minute.
+			std::thread::sleep(std::time::Duration::from_millis(1000));
 			prices.push(self.price(r.day)?)
 		}
 		self.progress.map(|p| p.finish_with_message("Prices Fetched"));

--- a/src/api.rs
+++ b/src/api.rs
@@ -101,7 +101,7 @@ impl<'a> Api<'a> {
 		// first, get rewards from the first page
 		let reward = self.rewards(0, 10).context("Failed to fetch initial reward page")?;
 		let total_pages = reward.count / 10;
-		rewards.extend(reward.list.into_iter());
+		rewards.extend(reward.list.into_iter().flatten());
 
 		self.progress.map(|p| p.set_message("Fetching Rewards"));
 		self.progress.map(|p| p.set_length(total_pages as u64));
@@ -115,6 +115,7 @@ impl<'a> Api<'a> {
 				.with_context(|| format!("Failed to fetch page {} of {}", i, total_pages))?
 				.list
 				.into_iter()
+				.flatten()
 			);
 		}
 		// TODO: this is kind of cheating but it's easier than trying to query just what we need

--- a/src/api.rs
+++ b/src/api.rs
@@ -131,7 +131,7 @@ impl<'a> Api<'a> {
 				self.rewards(i, PAGE_SIZE).with_context(|| format!("Failed to fetch page {}", i)).unwrap().list
 			})
 			.take_while(|list| list.is_some())
-			.filter_map(|list| list)
+			.flatten()
 			.flatten()
 			.filter(|r| {
 				let timestamp = NaiveDateTime::from_timestamp(r.block_timestamp.try_into().unwrap(), 0);

--- a/src/api.rs
+++ b/src/api.rs
@@ -105,7 +105,7 @@ impl<'a> Api<'a> {
 		let total_pages = self.rewards(0, 1).context("Failed to fetch initial reward page")?.count / 100;
 
 		self.progress.map(|p| p.set_message("Fetching Rewards"));
-		self.progress.map(|p| p.set_length(total_pages as u64));
+		self.progress.map(|p| p.set_length(total_pages.try_into().unwrap()));
 
 		let rewards: Vec<Reward> = (0..total_pages)
 			.filter_map(|i| {
@@ -119,7 +119,7 @@ impl<'a> Api<'a> {
 			})
 			.flatten()
 			.filter(|r| {
-				let timestamp = NaiveDateTime::from_timestamp(r.block_timestamp as i64, 0);
+				let timestamp = NaiveDateTime::from_timestamp(r.block_timestamp.try_into().unwrap(), 0);
 				let from = if let Some(from) = self.app.from { timestamp >= from } else { true };
 				let to = if let Some(to) = self.app.to { timestamp <= to } else { true };
 				from && to
@@ -150,7 +150,7 @@ impl<'a> Api<'a> {
 	/// Returns a vector of prices corresponding to the passed-in vector of Rewards.
 	pub fn fetch_prices(&self, rewards: &[RewardEntry]) -> Result<Vec<Price>, Error> {
 		self.progress.map(|p| p.reset());
-		self.progress.map(|p| p.set_length(rewards.len() as u64));
+		self.progress.map(|p| p.set_length(rewards.len().try_into().unwrap()));
 		self.progress.map(|p| p.set_message("Fetching Price Data"));
 		let mut prices = Vec::new();
 		for r in rewards.iter() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -119,7 +119,8 @@ impl<'a> Api<'a> {
 
 		let rewards: Vec<Reward> = (0..total_pages).filter_map(|i| {
 			self.progress.map(|p| p.inc(1));
-			std::thread::sleep(std::time::Duration::from_millis(35));
+			// subscan allows 10 requests per second
+			std::thread::sleep(std::time::Duration::from_millis(100));
 			self.rewards(i, 100)
 				.with_context(|| format!("Failed to fetch page {} of {}", i, total_pages))
 				.unwrap()
@@ -158,8 +159,8 @@ impl<'a> Api<'a> {
 		let mut prices = Vec::new();
 		for r in rewards.iter() {
 			self.progress.map(|p| p.inc(1));
-			// we're rate limited at 10 req/s
-			std::thread::sleep(std::time::Duration::from_millis(35));
+			// coingecko allows 100 requests per minute
+			std::thread::sleep(std::time::Duration::from_millis(600));
 			prices.push(self.price(r.timestamp)?)
 		}
 		self.progress.map(|p| p.finish_with_message("Prices Fetched"));

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,7 +23,7 @@ use crate::{
 use anyhow::{Context, Error};
 use chrono::naive::NaiveDateTime;
 use indicatif::ProgressBar;
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::BTreeMap, convert::TryInto};
 
 const POLKADOT_ENDPOINT: &str = "https://polkadot.subscan.io/api/";
 const KUSAMA_ENDPOINT: &str = "https://kusama.subscan.io/api/";
@@ -130,7 +130,7 @@ impl<'a> Api<'a> {
 		self.progress.map(|p| p.finish());
 
 		// merge all entries from the same day
-		let mut merged = HashMap::new();
+		let mut merged = BTreeMap::new();
 		for reward in rewards {
 			let day =
 				NaiveDateTime::from_timestamp(reward.block_timestamp.try_into()?, 0).format("%Y-%m-%d").to_string();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,13 +17,10 @@
 use crate::{api::Api, primitives::CsvRecord};
 use anyhow::{anyhow, bail, Context, Error};
 use argh::FromArgs;
-use chrono::{
-	naive::NaiveDateTime,
-	offset::{TimeZone, Utc},
-};
+use chrono::{naive::NaiveDateTime, offset::Utc};
 use env_logger::{Builder, Env};
 use indicatif::{ProgressBar, ProgressStyle};
-use std::{convert::TryInto, fs::File, io, path::PathBuf, str::FromStr};
+use std::{fs::File, io, path::PathBuf, str::FromStr};
 
 const OUTPUT_DATE: &str = "%Y-%m-%d";
 
@@ -135,7 +132,7 @@ pub fn app() -> Result<(), Error> {
 	for (reward, price) in rewards.iter().zip(prices.iter()) {
 		wtr.serialize(CsvRecord {
 			block_num: reward.block_num,
-			block_time: Utc.timestamp(reward.timestamp.try_into()?, 0).format(&app.date_format).to_string(),
+			block_time: reward.day.format(&app.date_format).to_string(),
 			amount: amount_to_network(&app.network, &reward.amount),
 			price: *price.market_data.current_price.get(&app.currency).ok_or_else(|| {
 				anyhow!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,14 +136,14 @@ pub fn app() -> Result<(), Error> {
 		wtr.serialize(CsvRecord {
 			block_num: reward.block_num,
 			block_time: {
-				let time = Utc.timestamp(reward.block_timestamp.try_into()?, 0);
+				let time = Utc.timestamp(reward.timestamp.try_into()?, 0);
 				if let Some(date_format) = &app.date_format {
 					time.format(&date_format).to_string()
 				} else {
 					time.to_rfc2822()
 				}
 			},
-			amount: amount_to_network(&app.network, &reward.amount)?,
+			amount: amount_to_network(&app.network, &reward.amount),
 			price: *price.market_data.current_price.get(&app.currency)
 				.ok_or_else(||
 					anyhow!(
@@ -173,10 +173,10 @@ fn construct_progress_bar() -> ProgressBar {
 	bar
 }
 
-fn amount_to_network(network: &Network, amount: &str) -> Result<f64, Error> {
+fn amount_to_network(network: &Network, amount: &u128) -> f64 {
 	match network {
-		Network::Polkadot => Ok(f64::from_str(amount)? / (10000000000f64)),
-		Network::Kusama => Ok(f64::from_str(amount)? / (1000000000000f64)),
+		Network::Polkadot => *amount as f64 / (10000000000f64),
+		Network::Kusama => *amount as f64 / (1000000000000f64),
 	}
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,10 +128,12 @@ pub fn app() -> Result<(), Error> {
 
 	let mut wtr = Output::new(&app).context("Failed to create output.")?;
 
-	for (reward, price) in rewards.iter().zip(prices.iter()) {
+	for (reward, price) in rewards.into_iter().zip(prices) {
 		wtr.serialize(CsvRecord {
-			block_num: reward.block_num,
-			block_time: reward.day.format(&app.date_format).to_string(),
+			block_nums: reward.block_nums.into_iter().fold(String::new(), |acc, i| {
+				format!("{}|{}", acc, i)
+			}),
+			date: reward.day.format(&app.date_format).to_string(),
 			amount: amount_to_network(&app.network, &reward.amount),
 			price: *price.market_data.current_price.get(&app.currency).ok_or_else(|| {
 				anyhow!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,7 +172,7 @@ fn amount_to_network(network: &Network, amount: &u128) -> f64 {
 // constructs a file name in the format: `dot-address-from_date-to_date-rewards.csv`
 fn construct_file_name(app: &App, rewards: &[RewardEntry]) -> String {
 	format!(
-		"{}-{}-{}-{}-rewards",
+		"{}-{}-{}--{}-rewards",
 		app.network.id(),
 		&app.address,
 		rewards.first().unwrap().day.format(OUTPUT_DATE),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -188,11 +188,13 @@ enum Output {
 
 impl Output {
 	fn new(app: &App) -> Result<Self, Error> {
+		let mut builder = csv::WriterBuilder::new();
+		builder.delimiter(b';');
 		if app.stdout {
-			Ok(Output::StdOut(csv::Writer::from_writer(io::stdout())))
+			Ok(Output::StdOut(builder.from_writer(io::stdout())))
 		} else {
 			let file = File::create(&app.folder)?;
-			Ok(Output::FileOut(csv::Writer::from_writer(file)))
+			Ok(Output::FileOut(builder.from_writer(file)))
 		}
 	}
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,7 @@ pub enum Network {
 impl Network {
 	pub fn id(&self) -> &'static str {
 		match self {
-			Self::Polkadot => "polkdadot",
+			Self::Polkadot => "polkadot",
 			Self::Kusama => "kusama",
 		}
 	}

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -16,7 +16,7 @@
 
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiResponse<T> {
@@ -66,7 +66,7 @@ pub struct Reward {
 
 #[derive(Debug)]
 pub struct RewardEntry {
-	pub block_nums: Vec<u64>,
+	pub block_nums: BTreeSet<u64>,
 	pub day: NaiveDate,
 	pub amount: u128,
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -34,7 +34,7 @@ impl<T> ApiResponse<T> {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct List<T> {
 	pub count: usize,
-	pub list: Vec<T>,
+	pub list: Option<Vec<T>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -15,6 +15,7 @@
 // along with polkadot-rewards.  If not, see <http://www.gnu.org/licenses/>.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiResponse<T> {
@@ -39,17 +40,12 @@ pub struct List<T> {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Price {
-	pub price: String,
-	pub time: usize,
-	pub height: usize,
-	pub records: Vec<Record>,
+	pub market_data: MarketData,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Record {
-	price: String,
-	height: usize,
-	time: usize,
+pub struct MarketData {
+	pub current_price: HashMap<String, f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -74,5 +70,4 @@ pub struct CsvRecord {
 	pub block_time: String,
 	pub amount: f64,
 	pub price: f64,
-	pub time: String,
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -51,8 +51,8 @@ pub struct MarketData {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Reward {
 	pub event_index: String,
-	pub block_num: usize,
-	pub extrinsic_idx: usize,
+	pub block_num: u64,
+	pub extrinsic_idx: u64,
 	pub module_id: String,
 	pub event_id: String,
 	pub params: serde_json::Value, // leaving this as general type because we don't need it and i'm lazy
@@ -63,10 +63,17 @@ pub struct Reward {
 	pub slash_kton: String,
 }
 
+#[derive(Debug)]
+pub struct RewardEntry {
+	pub block_num: u64,
+	pub timestamp: usize,
+	pub amount: u128,
+}
+
 // "block_num,block_time,amount_dot,price_usd,price_time"
 #[derive(Debug, Serialize)]
 pub struct CsvRecord {
-	pub block_num: usize,
+	pub block_num: u64,
 	pub block_time: String,
 	pub amount: f64,
 	pub price: f64,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -66,7 +66,7 @@ pub struct Reward {
 
 #[derive(Debug)]
 pub struct RewardEntry {
-	pub block_num: u64,
+	pub block_nums: Vec<u64>,
 	pub day: NaiveDate,
 	pub amount: u128,
 }
@@ -74,8 +74,8 @@ pub struct RewardEntry {
 // "block_num,block_time,amount_dot,price_usd,price_time"
 #[derive(Debug, Serialize)]
 pub struct CsvRecord {
-	pub block_num: u64,
-	pub block_time: String,
+	pub block_nums: String,
+	pub date: String,
 	pub amount: f64,
 	pub price: f64,
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -74,8 +74,8 @@ pub struct RewardEntry {
 // "block_num,block_time,amount_dot,price_usd,price_time"
 #[derive(Debug, Serialize)]
 pub struct CsvRecord {
-	pub block_nums: String,
 	pub date: String,
 	pub amount: f64,
 	pub price: f64,
+	pub block_nums: String,
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-rewards.  If not, see <http://www.gnu.org/licenses/>.
 
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -66,7 +67,7 @@ pub struct Reward {
 #[derive(Debug)]
 pub struct RewardEntry {
 	pub block_num: u64,
-	pub timestamp: usize,
+	pub day: NaiveDate,
 	pub amount: u128,
 }
 


### PR DESCRIPTION
- Support other currencies than USD (needed that for german tax)
- Merge all reward events that happened on the same day (coingecko historic API only reports price once per day)
- Improve error reporting
- Bugfixes and quality of life fixes

The merge of same day events is also useful to keep the amount of entries to a manageable level for the tax office.